### PR TITLE
Change absolute python shebang to env call.

### DIFF
--- a/bin/change_name.py
+++ b/bin/change_name.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from Bio import SeqIO
 import os
 import sys

--- a/bin/extract_gene_fasta.py
+++ b/bin/extract_gene_fasta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from Bio import SeqIO
 import sys
 


### PR DESCRIPTION
Change direct python shebang to call python via env binary.
This allow run this script with non-standard python path, for example - execute python from Conda environment.